### PR TITLE
tweaks for scorep profiling

### DIFF
--- a/src/solver_2d.f90
+++ b/src/solver_2d.f90
@@ -934,7 +934,6 @@ CONTAINS
 
           !$OMP ATOMIC
           dt = MIN(dt,dt_cfl)
-          !$OMP END ATOMIC
 
        END DO
        !$OMP END DO

--- a/src/solver_2d.f90
+++ b/src/solver_2d.f90
@@ -2676,7 +2676,7 @@ CONTAINS
 
        !$OMP DO private(j,k,i,fluxL,fluxR,flux_avg_x)
 
-       interfaces_x_loop:DO l = 1,solve_interfaces_x
+       x_interfaces_loop:DO l = 1,solve_interfaces_x
 
           j = j_stag_x(l)
           k = k_stag_x(l)
@@ -2723,7 +2723,7 @@ CONTAINS
 
           END IF
 
-       END DO interfaces_x_loop
+       END DO x_interfaces_loop
 
        !$OMP END DO NOWAIT
 
@@ -2735,7 +2735,7 @@ CONTAINS
 
        !$OMP DO private(j,k,i,fluxB,fluxT,flux_avg_y)
        
-       interfaces_y_loop:DO l = 1,solve_interfaces_y
+       y_interfaces_loop:DO l = 1,solve_interfaces_y
 
           j = j_stag_y(l)
           k = k_stag_y(l)
@@ -2782,7 +2782,7 @@ CONTAINS
 
           END IF
 
-       END DO interfaces_y_loop
+       END DO y_interfaces_loop
 
        !$OMP END DO
 


### PR DESCRIPTION
These 2 small changes don't affect any logic of the code or OMP parallelization, but work around bugs in scorep and opari2 .  With the changes it's possible to compile with ``make -FC="scorep-gfortran"`` for parallel profiling with scorep/scalasca .
- removed an optional ``!$OMP END ATOMIC`` line, scorep doesn't handle these on one-line atomic blocks
- renamed two tagged loop names which happen to start the line with ``interfaces...`` , this is to work around a bug in opari2 parsing where they are confused for a fortran interface block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity of comments related to boundary conditions and source terms in the solver module.

- **Refactor**
	- Enhanced readability by renaming loop labels for better understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->