### PR TITLE
Added sphericity parameter, initial permeability calculation for non dynamic permeability, and rheology .EQ. 12

### DIFF
--- a/src/constitutive_2d.f90
+++ b/src/constitutive_2d.f90
@@ -257,9 +257,7 @@ MODULE constitutive_2d
   REAL(wp) :: hydraulic_permeability 
   !> Flag to activate dynamic permeability
   LOGICAL :: dynamic_permeability_flag
-  !> Flag to activate permeability calculation at the initial timestep 
-  LOGICAL :: initial_permeability_flag
-
+  
   !> Maximum solid packing fraction
   REAL(wp) :: maximum_solid_packing 
 
@@ -515,14 +513,7 @@ CONTAINS
 
     WRITE(*,*) 'Implicit equations =',n_nh
 
-    ! Initialize permeability flags
-    ! If initial_permeability_flag is true, we will calculate permeability once and then turn off dynamic
-    IF ( initial_permeability_flag ) THEN
-       dynamic_permeability_flag = .TRUE.
-       WRITE(*,*) 'Permeability will be calculated once at t=0 using initial conditions'
-    END IF
-
-    RETURN
+  RETURN
 
   END SUBROUTINE init_problem_param
 
@@ -3694,32 +3685,8 @@ CONTAINS
                                    ( diam_sauter * sphericity_mean )**2.0_wp ) / &
                                    ( 150.0_wp * (1.0_wp - porosity)**2.0_wp )
          
-         ! If initial_permeability_flag is true, this is the first calculation
-         ! Turn off dynamic_permeability_flag so we don't recalculate
-         ! Calculate D_coeff using ambient conditions for display purposes
-         IF ( initial_permeability_flag ) THEN
-            gamma_gas = sp_heat_a / ( sp_heat_a - sp_gas_const_a )
-            gas_compressibility = 1.0_wp / ( gamma_gas * pres )
-            rho_gas = pres / ( sp_gas_const_a * T_ambient )
-            
-            D_coeff = hydraulic_permeability / ( porosity * kin_visc_c * rho_gas * &
-                 gas_compressibility )
-                 
-            dynamic_permeability_flag = .FALSE.
-            WRITE(*,*) '========================================='
-            WRITE(*,*) 'Initial permeability calculated'
-            WRITE(*,'(A,ES15.6)') ' Hydraulic permeability (m2):', REAL(hydraulic_permeability)
-            WRITE(*,'(A,ES15.6)') ' Sauter mean diameter (m):', REAL(diam_sauter)
-            WRITE(*,'(A,F8.4)')   ' Surface-area-weighted mean sphericity (-):', REAL(sphericity_mean)
-            WRITE(*,'(A,F8.4)')   ' Porosity (-):', REAL(porosity)
-            WRITE(*,'(A,ES15.6)') ' Diffusion coefficient (m2/s) at T_ambient:', REAL(D_coeff)
-            WRITE(*,*) '========================================='
-            WRITE(*,*) 'Dynamic permeability flag now turned OFF'
-            WRITE(*,*) 'Using constant permeability value'
-            WRITE(*,*) '========================================='
-         END IF
-         
-       END IF
+       END IF          
+       
        ! ---------------------------------------------------------
 
        IF ( gas_flag .AND. sutherland_flag ) THEN
@@ -4882,12 +4849,7 @@ CONTAINS
                                       ( diam_sauter * sphericity_mean )**2.0_wp ) / &
                                       ( 150.0_wp * (alphas_tot)**2.0_wp )
             
-            ! If initial_permeability_flag is true, this is the first calculation
-            ! Turn off dynamic_permeability_flag so we don't recalculate
-            IF ( initial_permeability_flag ) THEN
-               dynamic_permeability_flag = .FALSE.
-            END IF
-            
+                        
           END IF
 	! -------------------------------------------------------------------- !
 

--- a/src/inpout_2d.f90
+++ b/src/inpout_2d.f90
@@ -519,7 +519,7 @@ CONTAINS
     hydraulic_permeability = 0.0_wp
     pore_pres_fract = -1.0_wp
     gas_loss_flag = .FALSE.
-    alpha_trans = 0.0_wp
+    alpha_trans = 1.0_wp
     f_inhibit_mode = 'OFF'
     dynamic_permeability_flag = .FALSE.
     initial_permeability_flag = .FALSE.
@@ -663,16 +663,6 @@ CONTAINS
                 STOP
 	      END IF             
 	   END IF
-
-
-
-	IF ( alpha_trans .LE. 0.0_wp ) THEN
-             WRITE(*,*) 'ERROR: problem with namelist PORE_PRESSURE_PARAMETERS'
-             WRITE(*,*) 'alpha_trans =' , alpha_trans
-             WRITE(*,*) 'Please check the alpha_trans is > 0.0'
-             STOP
-          END IF
-
 
          ! Normalize and validate f_inhibit_mode (require uppercase tokens in input)
          f_inhibit_mode = trim(adjustl(f_inhibit_mode))

--- a/src/inpout_2d.f90
+++ b/src/inpout_2d.f90
@@ -122,7 +122,7 @@ MODULE inpout_2d
   USE parameters_2d, ONLY : output_stoch_vars_flag, length_spatial_corr   
 
   ! --- Variables for the namelist PORE_PRESSURE_PARAMETERS
-  USE constitutive_2d, ONLY : hydraulic_permeability, dynamic_permeability_flag, initial_permeability_flag
+  USE constitutive_2d, ONLY : hydraulic_permeability, dynamic_permeability_flag
   USE constitutive_2d, ONLY : alpha_trans, N_inh, f_inhibit_mode, pascal_coeff_precomputed ! for f_inhibit
   USE parameters_2d, ONLY : pore_pres_fract
   USE parameters_2d, ONLY : gas_loss_flag
@@ -373,7 +373,7 @@ MODULE inpout_2d
 
   NAMELIST / pore_pressure_parameters / hydraulic_permeability, pore_pres_fract,&
        gas_loss_flag, alpha_trans, N_inh, f_inhibit_mode,                       &
-       dynamic_permeability_flag, initial_permeability_flag
+       dynamic_permeability_flag
   
 CONTAINS
 
@@ -522,7 +522,6 @@ CONTAINS
     alpha_trans = 0.0_wp
     f_inhibit_mode = 'OFF'
     dynamic_permeability_flag = .FALSE.
-    initial_permeability_flag = .FALSE.
     pascal_coeff_precomputed = .FALSE.
    
     
@@ -664,7 +663,7 @@ CONTAINS
 	      END IF             
 	   END IF
 
-         ! Normalize and validate f_inhibit_mode (require uppercase tokens in input)
+           ! Normalize and validate f_inhibit_mode (require uppercase tokens in input)
          f_inhibit_mode = trim(adjustl(f_inhibit_mode))
          IF ( .NOT. ( f_inhibit_mode == 'OFF' .OR. f_inhibit_mode == 'STEP' .OR.  &
                      f_inhibit_mode == 'STATIC' .OR. f_inhibit_mode == 'DYNAMIC' ) ) THEN
@@ -686,9 +685,18 @@ CONTAINS
                STOP
             END IF
             
+            IF ( alpha_trans .LE. 0.0_wp ) THEN
+               WRITE(*,*) 'ERROR: problem with namelist PORE_PRESSURE_PARAMETERS'
+               WRITE(*,*) 'alpha_trans =' , alpha_trans
+               WRITE(*,*) 'Please check that alpha_trans is > 0.0 when F_INHIBIT_MODE is STATIC or DYNAMIC'
+               STOP
+            END IF
+
          END IF
 
-
+          
+         
+         
 
        ELSE
 
@@ -696,7 +704,7 @@ CONTAINS
 
           WRITE(*,*) 'NOTE: PORE_PRESSURE_FLAG is FALSE. Pore pressure equation will not be solved.'
           WRITE(*,*) 'HYDRAULIC_PERMEABILITY, F_INHIBIT_MODE, ALPHA_TRANS, and PORE_PRESSURE_FRACTION will not be accounted for.'
-          WRITE(*,*) 'GAS_LOSS_FLAG, DYNAMIC_PERMEABILITY_FLAG, and INITIAL_PERMEABILITY_FLAG will be set to FALSE.'
+          WRITE(*,*) 'GAS_LOSS_FLAG and DYNAMIC_PERMEABILITY_FLAG will be set to FALSE.'
 
        END IF
           

--- a/src/inpout_2d.f90
+++ b/src/inpout_2d.f90
@@ -519,7 +519,7 @@ CONTAINS
     hydraulic_permeability = 0.0_wp
     pore_pres_fract = -1.0_wp
     gas_loss_flag = .FALSE.
-    alpha_trans = 1.0_wp
+    alpha_trans = 0.0_wp
     f_inhibit_mode = 'OFF'
     dynamic_permeability_flag = .FALSE.
     initial_permeability_flag = .FALSE.


### PR DESCRIPTION
This PR adds:
   - Sphericity parameter for particles (defaults to 1.0)
   - Surface-area-weighted mean sphericity consistent with Sauter diameter
   - Initial permeability flag to calculate permeability once at t=0 based on initial parameters rather than user-estimated one to avoid inconsistencies
   - Modified Carman-Kozeny equation including sphericity (See Breard et al. 2019, JGR)
   - Rheology model 12: μ(I) + Voellmy with pore pressure effects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sediment sphericity parameter (0–1, default 1.0) and updated permeability to account for particle sphericity.
  * Added support for an additional rheology mode (treated like the mu(I) branch) with corresponding friction/centrifugal handling.

* **Improvements**
  * Stronger validation and clearer error/info messages for sediment and rheology parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->